### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@ DragLayout
 
 * 使用support.v4包下的ViewDragHelper实现QQ5.0侧滑
 
-##Screenshots
+## Screenshots
 ![image](https://github.com/BlueMor/DragLayout/blob/master/screenshots/123.gif)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
